### PR TITLE
Use H5 for pure keras models

### DIFF
--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -15,7 +15,7 @@ class TestCallbacks(asynctest.AsyncTestCase):
         cb = callbacks.ModelCheckpoint(verbose=1)
 
         model = tf.keras.models.Sequential()
-        model.add(tf.keras.layers.Activation("tanh"))
+        model.add(tf.keras.layers.Dense(1, input_shape=(1,)))
         model.compile(optimizer="sgd", loss="binary_crossentropy")
 
         x, y = np.array([[1.0]]), np.array([[1.0]])


### PR DESCRIPTION
When callback is used with keras model, it must be saved into h5 first.
This fixes an issue with "save_model" function that accepts
"save_format" attribute that is not recongnizable by Keras library.