### PR TITLE
Add "predict" method to client

### DIFF
--- a/tensorcraft/__init__.py
+++ b/tensorcraft/__init__.py
@@ -1,6 +1,6 @@
 import pathlib
 
-__version__ = "0.0.1b4"
+__version__ = "0.0.1b5"
 __apiversion__ = "1.0.0"
 
 

--- a/tests/cryptotest.py
+++ b/tests/cryptotest.py
@@ -1,5 +1,6 @@
 import datetime
 import math
+import numpy
 import pathlib
 import random
 import string
@@ -24,6 +25,10 @@ def random_bytes(length=1024):
 
 def random_dict(items=10):
     return {random_string(): random_string() for _ in range(items)}
+
+
+def random_array(length=10) -> list:
+    return numpy.random.uniform(0, 1, size=length).tolist()
 
 
 def create_self_signed_cert(path: pathlib.Path) -> Tuple[pathlib.Path,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
 import aiohttp.test_utils as aiohttptest
 import aiohttp.web
 import io
+import numpy
 import pathlib
 import unittest
 
@@ -107,6 +108,20 @@ class TestClient(asynctest.AsyncTestCase):
             await client.export(m.name, m.tag, asynclib.AsyncIO(writer))
 
             self.assertEqual(want_value, writer.getvalue())
+
+    @asynctest.unittest_run_loop
+    async def test_predict(self):
+        m = kerastest.new_model()
+        path = f"/models/{m.name}/{m.tag}/predict"
+
+        y_true = [cryptotest.random_array()]
+        resp = aiohttp.web.json_response(data=dict(y=y_true))
+
+        async with self.handle_request("POST", path, resp) as client:
+            x_pred = cryptotest.random_array()
+            y_pred = await client.predict(m.name, m.tag, [x_pred])
+
+            self.assertTrue(numpy.array_equal(y_true, y_pred))
 
     @asynctest.unittest_run_loop
     async def test_push(self):


### PR DESCRIPTION
This patch adds "predict" method to the TC client in order to retrieve
predictions of the model.